### PR TITLE
Define multiple C translation units

### DIFF
--- a/examples/C.hs
+++ b/examples/C.hs
@@ -19,12 +19,17 @@ type L =
 -- | Define a function in another module and call it.
 multiModule :: Program L ()
 multiModule = do
+  addInclude "<stdlib.h>"
+  addExternProc "func_in_other" []
   inModule "other" $ do
-    addInclude "<stdlib.h>"
     addDefinition [cedecl|
       void func_in_other(void) {
         puts("Hello from the other module!");
       } |]
-  addInclude "<stdlib.h>"
-  addExternProc "func_in_other" []
+    addInclude "<stdio.h>"
   callProc "func_in_other" []
+
+----------------------------------------
+
+testAll = do
+    icompileAll multiModule

--- a/examples/C.hs
+++ b/examples/C.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeOperators #-}
+
+module C where
+
+import Prelude hiding (break)
+
+import Language.C.Quote.C
+import Language.Embedded.Imperative
+import Language.Embedded.Concurrent
+import Language.Embedded.Backend.C
+import Language.Embedded.CExp
+
+type L =
+  C_CMD CExp :+:
+  FileCMD CExp
+
+-- | Define a function in another module and call it.
+multiModule :: Program L ()
+multiModule = do
+  inModule "other" $ do
+    addInclude "<stdlib.h>"
+    addDefinition [cedecl|
+      void func_in_other(void) {
+        puts("Hello from the other module!");
+      } |]
+  addInclude "<stdlib.h>"
+  addExternProc "func_in_other" []
+  callProc "func_in_other" []

--- a/src/Language/C/Monad.hs
+++ b/src/Language/C/Monad.hs
@@ -212,12 +212,12 @@ cenvToCUnit env =
     globs  = nub $ reverse $ _globals env
 
 -- | Generate a C document
-prettyCGenT :: Monad m => CGenT m a -> m Doc
+prettyCGenT :: Monad m => CGenT m a -> m [(String, Doc)]
 prettyCGenT ma = do
     (_,cenv) <- runCGenT ma (defaultCEnv Flags)
-    return $ ppr $ cenvToCUnit cenv
+    return $ map (("", ppr) <*>) $ ("main", cenvToCUnit cenv) : Map.toList (_modules cenv)
 
-prettyCGen :: CGen a -> Doc
+prettyCGen :: CGen a -> [(String, Doc)]
 prettyCGen = runIdentity . prettyCGenT
 
 -- | Retrieve a fresh identifier

--- a/src/Language/C/Monad.hs
+++ b/src/Language/C/Monad.hs
@@ -215,7 +215,8 @@ cenvToCUnit env =
 prettyCGenT :: Monad m => CGenT m a -> m [(String, Doc)]
 prettyCGenT ma = do
     (_,cenv) <- runCGenT ma (defaultCEnv Flags)
-    return $ map (("", ppr) <*>) $ ("main", cenvToCUnit cenv) : Map.toList (_modules cenv)
+    return $ map (("", ppr) <*>)
+           $ ("main", cenvToCUnit cenv) : Map.toList (_modules cenv)
 
 prettyCGen :: CGen a -> [(String, Doc)]
 prettyCGen = runIdentity . prettyCGenT

--- a/src/Language/C/Monad.hs
+++ b/src/Language/C/Monad.hs
@@ -211,7 +211,7 @@ cenvToCUnit env =
     protos = nub $ reverse $ _prototypes env
     globs  = nub $ reverse $ _globals env
 
--- | Generate a C document
+-- | Generate C documents for each module
 prettyCGenT :: Monad m => CGenT m a -> m [(String, Doc)]
 prettyCGenT ma = do
     (_,cenv) <- runCGenT ma (defaultCEnv Flags)

--- a/src/Language/Embedded/Backend/C.hs
+++ b/src/Language/Embedded/Backend/C.hs
@@ -59,6 +59,9 @@ arrayInit as = C.CompoundInitializer
 
 -- | Compile a program to C code represented as a string
 --
+-- This function returns only the first (main) module.
+-- To get every C translation units, use `compileAll`.
+--
 -- For programs that make use of the primitives in
 -- "Language.Embedded.Concurrent", the resulting C code can be compiled as
 -- follows:
@@ -71,6 +74,9 @@ compileAll :: (Interp instr CGen, HFunctor instr) => Program instr a -> [(String
 compileAll = map (("", pretty 80) <*>) . prettyCGen . liftSharedLocals . wrapMain . interpret
 
 -- | Compile a program to C code and print it on the screen
+--
+-- This function returns only the first (main) module.
+-- To get every C translation units, use `icompileAll`.
 --
 -- For programs that make use of the primitives in
 -- "Language.Embedded.Concurrent", the resulting C code can be compiled as
@@ -112,6 +118,8 @@ maybePutStrLn :: Bool -> String -> IO ()
 maybePutStrLn False str = putStrLn str
 maybePutStrLn _ _ = return ()
 
+-- TODO: it would be nice to have a version that compiles all modules of a program,
+-- as it currently compiles only the first (main) module.
 -- | Generate C code and use GCC to compile it
 compileC :: (Interp instr CGen, HFunctor instr)
     => ExternalCompilerOpts

--- a/src/Language/Embedded/Backend/C.hs
+++ b/src/Language/Embedded/Backend/C.hs
@@ -65,7 +65,10 @@ arrayInit as = C.CompoundInitializer
 --
 -- > gcc -Iinclude csrc/chan.c -lpthread YOURPROGRAM.c
 compile :: (Interp instr CGen, HFunctor instr) => Program instr a -> String
-compile = pretty 80 . prettyCGen . liftSharedLocals . wrapMain . interpret
+compile = snd . head . compileAll
+
+compileAll :: (Interp instr CGen, HFunctor instr) => Program instr a -> [(String, String)]
+compileAll = map (("", pretty 80) <*>) . prettyCGen . liftSharedLocals . wrapMain . interpret
 
 -- | Compile a program to C code and print it on the screen
 --
@@ -76,6 +79,9 @@ compile = pretty 80 . prettyCGen . liftSharedLocals . wrapMain . interpret
 -- > gcc -Iinclude csrc/chan.c -lpthread YOURPROGRAM.c
 icompile :: (Interp instr CGen, HFunctor instr) => Program instr a -> IO ()
 icompile = putStrLn . compile
+
+icompileAll :: (Interp instr CGen, HFunctor instr) => Program instr a -> IO ()
+icompileAll = mapM_ (\(n, m) -> putStrLn ("// module " ++ n) >> putStrLn m) . compileAll
 
 removeFileIfPossible :: FilePath -> IO ()
 removeFileIfPossible file =

--- a/src/Language/Embedded/Imperative/Backend/C.hs
+++ b/src/Language/Embedded/Imperative/Backend/C.hs
@@ -253,6 +253,7 @@ compC_CMD (CallProc obj fun as) = do
     case obj of
       Nothing -> addStm [cstm| $id:fun($args:as'); |]
       Just o  -> addStm [cstm| $id:o = $id:fun($args:as'); |]
+compC_CMD (InModule mod prog) = inModule mod prog
 
 instance CompExp exp => Interp (RefCMD exp)     CGen where interp = compRefCMD
 instance CompExp exp => Interp (ControlCMD exp) CGen where interp = compControlCMD

--- a/src/Language/Embedded/Imperative/CMD.hs
+++ b/src/Language/Embedded/Imperative/CMD.hs
@@ -460,6 +460,7 @@ data C_CMD exp (prog :: * -> *) a
     AddExternProc :: String -> [FunArg exp] -> C_CMD exp prog ()
     CallFun       :: VarPred exp a => String -> [FunArg exp] -> C_CMD exp prog (exp a)
     CallProc      :: Assignable obj => Maybe obj -> String -> [FunArg exp] -> C_CMD exp prog ()
+    InModule      :: String -> prog () -> C_CMD exp prog ()
 
 instance HFunctor (C_CMD exp)
   where
@@ -472,6 +473,7 @@ instance HFunctor (C_CMD exp)
     hfmap _ (AddExternProc proc args)   = AddExternProc proc args
     hfmap _ (CallFun fun args)          = CallFun fun args
     hfmap _ (CallProc obj proc args)    = CallProc obj proc args
+    hfmap f (InModule mod prog)         = InModule mod (f prog)
 
 instance FreeExp exp => DryInterp (C_CMD exp)
   where
@@ -484,6 +486,7 @@ instance FreeExp exp => DryInterp (C_CMD exp)
     dryInterp (AddExternProc _ _)    = return ()
     dryInterp (CallFun _ _)          = liftM varExp $ freshStr "v"
     dryInterp (CallProc _ _ _)       = return ()
+    dryInterp (InModule _ _)         = return ()
 
 type instance IExp (C_CMD e)       = e
 type instance IExp (C_CMD e :+: i) = e
@@ -620,6 +623,7 @@ runC_CMD (AddExternFun _ _ _) = return ()
 runC_CMD (AddExternProc _ _)  = return ()
 runC_CMD (CallFun _ _)        = error "cannot run programs involving callFun"
 runC_CMD (CallProc _ _ _)     = error "cannot run programs involving callProc"
+runC_CMD (InModule _ prog)    = prog
 
 instance EvalExp exp => Interp (RefCMD exp)     IO where interp = runRefCMD
 instance EvalExp exp => Interp (ArrCMD exp)     IO where interp = runArrCMD

--- a/src/Language/Embedded/Imperative/Frontend.hs
+++ b/src/Language/Embedded/Imperative/Frontend.hs
@@ -458,6 +458,13 @@ newNamedObject :: (C_CMD (IExp instr) :<: instr)
     -> ProgramT instr m Object
 newNamedObject base t p = singleE $ NewObject base t p
 
+-- | Generate code into another translation unit
+inModule :: (C_CMD (IExp instr) :<: instr)
+    => String
+    -> ProgramT instr m ()
+    -> ProgramT instr m ()
+inModule mod cmd = singleE $ InModule mod cmd
+
 -- | Add an @#include@ statement to the generated code
 addInclude :: (C_CMD (IExp instr) :<: instr) => String -> ProgramT instr m ()
 addInclude = singleE . AddInclude

--- a/src/Language/Embedded/Imperative/Frontend.hs
+++ b/src/Language/Embedded/Imperative/Frontend.hs
@@ -463,7 +463,7 @@ inModule :: (C_CMD (IExp instr) :<: instr)
     => String
     -> ProgramT instr m ()
     -> ProgramT instr m ()
-inModule mod cmd = singleE $ InModule mod cmd
+inModule mod prog = singleE $ InModule mod prog
 
 -- | Add an @#include@ statement to the generated code
 addInclude :: (C_CMD (IExp instr) :<: instr) => String -> ProgramT instr m ()


### PR DESCRIPTION
Adding the `InModule` instruction. See the new example file for usage.
