### PR TITLE
Correct lifting for array typed shared globals

### DIFF
--- a/src/Language/C/Monad.hs
+++ b/src/Language/C/Monad.hs
@@ -415,7 +415,10 @@ liftSharedLocals prog = do
     let (globs, shared) = unzip $ map (extractDecls (`Set.member` uvs)) oldglobs
         sharedList = Set.toList $ Set.unions shared
         sharedDecls = map (\ig -> C.DecDef ig (SrcLoc NoLoc)) sharedList
-    void $ globals <<.= (globs ++ sharedDecls)
+    -- Reverse is a trick that ensures the correct order of declarations for arrays
+    -- and their wrapper pointers. It depends on the naming schema of identifiers:
+    -- arrays are prefixed with underscores, while their wrappers are not.
+    void $ globals <<.= (globs ++ reverse sharedDecls)
   where
     -- Only keep vars shared between functions by intersecting with the union
     -- of all other funs' uvs. TODO: optimize.


### PR DESCRIPTION
When compiling multi-threading instructions to `pthread`, the common variables of the threads will be lifted to shared global declarations. Without this patch, arrays are lifted incorrectly: only the wrapper pointer will be lifted, which depends on the real array (the one that starts with an underscore). For example, when `a1` is used from two threads, the underlying `_a1` is not lifted. This causes a C compilation error, as `a1` will be initialized with the missing `_a1`.

This problem is not strictly related to multi-threading features, but currently this is the only case where multiple functions are generated.

Another interesting thing is that [compilation of a `CExp` expression](https://github.com/emilaxelsson/imperative-edsl/blob/master/src/Language/Embedded/CExp.hs#L288) does not contain any application of `touchVar`.  Does it mean that when the threads are only access an array with an indexing expression, it will not be lifted to a shared global? (As the variable usage information will be missing.) In that case, compilation of expressions should be reviewed and fixed accordingly.
