### PR TITLE
Changing format specifier of double - now scanf works correctly

### DIFF
--- a/src/Language/Embedded/Imperative/CMD.hs
+++ b/src/Language/Embedded/Imperative/CMD.hs
@@ -409,7 +409,7 @@ instance Formattable Word16 where formatSpecifier _ = "%u"
 instance Formattable Word32 where formatSpecifier _ = "%u"
 instance Formattable Word64 where formatSpecifier _ = "%lu"
 instance Formattable Float  where formatSpecifier _ = "%f"
-instance Formattable Double where formatSpecifier _ = "%f"
+instance Formattable Double where formatSpecifier _ = "%lf"
 
 data FileCMD fs a
   where


### PR DESCRIPTION
The `Formattable` class specifies both the `printf` and `scanf` formats for a type. For `double`, the `printf` format `%f` was correct, but it is not working with `scanf`, as it requires `%lf` for `double` values. Fortunately, this latter format specifier is also accepted by `printf`, so I changed it.
