### PR TITLE
Refactoring channels to support "untyped" reads and writes

### DIFF
--- a/examples/Concurrent.hs
+++ b/examples/Concurrent.hs
@@ -18,7 +18,8 @@ type CMD =
   ThreadCMD :+:
   ChanCMD :+:
   ControlCMD :+:
-  FileCMD
+  FileCMD :+:
+  ArrCMD
 
 type Prog = Program CMD (Param2 CExp CType)
 
@@ -93,6 +94,13 @@ chanOps = do
   writeChan c 42
   a <- readChan c
   b <- readChan c
+  printf "%d %d\n" a b
+  sent <- initArr [ 12, 34 ]
+  writeChanBuf c (0 :: CExp Int32) 2 sent
+  received <- newArr (2 :: CExp Int32)
+  readChanBuf c 0 2 received
+  a <- getArr 0 received
+  b <- getArr 1 received
   printf "%d %d\n" a b
   closeChan c
 

--- a/examples/Concurrent.hs
+++ b/examples/Concurrent.hs
@@ -21,7 +21,7 @@ type CMD =
   FileCMD
 
 type Prog = Program CMD (Param2 CExp CType)
-
+{-
 -- | Deadlocks due to channel becoming full.
 deadlock :: Prog ()
 deadlock = do
@@ -83,11 +83,12 @@ suicide = do
     printf "This is not. %d\n" (0 :: CExp Int32)
   waitThread tid
   printf "The thread is dead, long live the thread! %d\n" (0 :: CExp Int32)
+-}
 
 -- | Primitive channel operations.
 chanOps :: Prog ()
 chanOps = do
-  c <- newCloseableChan (2 :: CExp Word16)
+  c <- newCloseableChan (CSize (2 :: CExp Word32))
   writeChan c (1337 :: CExp Int32)
   writeChan c 42
   a <- readChan c
@@ -100,8 +101,8 @@ chanOps = do
 ----------------------------------------
 
 testAll = do
-    tag "waiting" >> compareCompiled' opts waiting (runIO waiting) ""
-    tag "suicide" >> compareCompiled' opts suicide (runIO suicide) ""
+--    tag "waiting" >> compareCompiled' opts waiting (runIO waiting) ""
+--    tag "suicide" >> compareCompiled' opts suicide (runIO suicide) ""
     tag "chanOps" >> compareCompiled' opts chanOps (runIO chanOps) ""
   where
     tag str = putStrLn $ "---------------- examples/Concurrent.hs/" ++ str ++ "\n"

--- a/examples/Concurrent.hs
+++ b/examples/Concurrent.hs
@@ -27,7 +27,7 @@ type Prog = Program CMD (Param2 CExp CType)
 -- | Deadlocks due to channel becoming full.
 deadlock :: Prog ()
 deadlock = do
-  c <- newChan 1
+  c <- newChan (1 :: CExp Word32)
   t <- fork $ readChan c >>= printf "%d\n"
   writeChan c (1 :: CExp Int32)
   writeChan c 2
@@ -38,8 +38,8 @@ deadlock = do
 --   happen in separate threads.
 mapFile :: (CExp Float -> CExp Float) -> FilePath -> Prog ()
 mapFile f i = do
-  c1 <- newCloseableChan 5
-  c2 <- newCloseableChan 5
+  c1 <- newCloseableChan (5 :: CExp Word32)
+  c2 <- newCloseableChan (5 :: CExp Word32)
   fi <- fopen i ReadMode
 
   t1 <- fork $ do
@@ -90,7 +90,7 @@ suicide = do
 -- | Primitive channel operations.
 chanOps :: Prog ()
 chanOps = do
-  c <- newCloseableChan 2
+  c <- newCloseableChan (2 :: CExp Word32)
   writeChan c (1337 :: CExp Int32)
   writeChan c 42
   a <- readChan c

--- a/examples/Concurrent.hs
+++ b/examples/Concurrent.hs
@@ -84,6 +84,17 @@ suicide = do
   waitThread tid
   printf "The thread is dead, long live the thread! %d\n" (0 :: CExp Int32)
 
+-- | Primitive channel operations.
+chanOps :: Prog ()
+chanOps = do
+  c <- newCloseableChan (2 :: CExp Word16)
+  writeChan c (1337 :: CExp Int32)
+  writeChan c 42
+  a <- readChan c
+  b <- readChan c
+  printf "%d %d\n" a b
+  closeChan c
+
 
 
 ----------------------------------------
@@ -91,7 +102,10 @@ suicide = do
 testAll = do
     tag "waiting" >> compareCompiled' opts waiting (runIO waiting) ""
     tag "suicide" >> compareCompiled' opts suicide (runIO suicide) ""
+    tag "chanOps" >> compareCompiled' opts chanOps (runIO chanOps) ""
   where
     tag str = putStrLn $ "---------------- examples/Concurrent.hs/" ++ str ++ "\n"
-    opts = defaultExtCompilerOpts {externalFlagsPost = ["-lpthread"]}
-
+    opts = defaultExtCompilerOpts
+         { externalFlagsPre  = ["-Iinclude", "csrc/chan.c"]
+         , externalFlagsPost = ["-lpthread"]
+         }

--- a/examples/Concurrent.hs
+++ b/examples/Concurrent.hs
@@ -21,11 +21,11 @@ type CMD =
   FileCMD
 
 type Prog = Program CMD (Param2 CExp CType)
-{-
+
 -- | Deadlocks due to channel becoming full.
 deadlock :: Prog ()
 deadlock = do
-  c <- newChan (1 :: CExp Word16)
+  c <- newChan 1
   t <- fork $ readChan c >>= printf "%d\n"
   writeChan c (1 :: CExp Int32)
   writeChan c 2
@@ -36,8 +36,8 @@ deadlock = do
 --   happen in separate threads.
 mapFile :: (CExp Float -> CExp Float) -> FilePath -> Prog ()
 mapFile f i = do
-  c1 <- newCloseableChan (5 :: CExp Word16)
-  c2 <- newCloseableChan (5 :: CExp Word16)
+  c1 <- newCloseableChan 5
+  c2 <- newCloseableChan 5
   fi <- fopen i ReadMode
 
   t1 <- fork $ do
@@ -83,13 +83,13 @@ suicide = do
     printf "This is not. %d\n" (0 :: CExp Int32)
   waitThread tid
   printf "The thread is dead, long live the thread! %d\n" (0 :: CExp Int32)
--}
+
 
 -- | Primitive channel operations.
 chanOps :: Prog ()
 chanOps = do
-  c :: Chan Closeable Int32 <- newCloseableChan 2
-  writeChan c 1337
+  c <- newCloseableChan 2
+  writeChan c (1337 :: CExp Int32)
   writeChan c 42
   a <- readChan c
   b <- readChan c
@@ -101,8 +101,8 @@ chanOps = do
 ----------------------------------------
 
 testAll = do
---    tag "waiting" >> compareCompiled' opts waiting (runIO waiting) ""
---    tag "suicide" >> compareCompiled' opts suicide (runIO suicide) ""
+    tag "waiting" >> compareCompiled' opts waiting (runIO waiting) ""
+    tag "suicide" >> compareCompiled' opts suicide (runIO suicide) ""
     tag "chanOps" >> compareCompiled' opts chanOps (runIO chanOps) ""
   where
     tag str = putStrLn $ "---------------- examples/Concurrent.hs/" ++ str ++ "\n"

--- a/examples/Concurrent.hs
+++ b/examples/Concurrent.hs
@@ -88,8 +88,8 @@ suicide = do
 -- | Primitive channel operations.
 chanOps :: Prog ()
 chanOps = do
-  c <- newCloseableChan (CSize (2 :: CExp Word32))
-  writeChan c (1337 :: CExp Int32)
+  c :: Chan Closeable Int32 <- newCloseableChan 2
+  writeChan c 1337
   writeChan c 42
   a <- readChan c
   b <- readChan c

--- a/examples/Concurrent.hs
+++ b/examples/Concurrent.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Concurrent where
@@ -95,13 +96,18 @@ chanOps = do
   a <- readChan c
   b <- readChan c
   printf "%d %d\n" a b
-  sent <- initArr [ 12, 34 ]
-  writeChanBuf c (0 :: CExp Int32) 2 sent
-  received <- newArr (2 :: CExp Int32)
-  readChanBuf c 0 2 received
+
+  sent :: Arr Int8 Int32 <- initArr [ 12, 34 ]
+  writeChanBuf c (0 :: CExp Int8) 2 sent
+  received <- newArr (2 :: CExp Int8)
+  readChanBuf c (0 :: CExp Int8) 2 received
   a <- getArr 0 received
   b <- getArr 1 received
   printf "%d %d\n" a b
+
+  writeChan' c (67 :: CExp Word8)
+  r :: CExp Word8 <- readChan' c
+  printf "%d\n" r
   closeChan c
 
 

--- a/imperative-edsl.cabal
+++ b/imperative-edsl.cabal
@@ -51,6 +51,7 @@ library
     Language.Embedded.Imperative.Backend.C
     Language.Embedded.Concurrent.Backend.C
       -- No need to export these since only the instances are interesting
+    Control.Chan
 
   default-language: Haskell2010
 

--- a/imperative-edsl.cabal
+++ b/imperative-edsl.cabal
@@ -101,7 +101,8 @@ library
     BoundedChan,
     srcloc,
     syntactic >= 3.2,
-    time >= 1.5.0.1
+    time >= 1.5.0.1,
+    stm >= 2.4 && < 2.5
 
   hs-source-dirs: src
 

--- a/src/Control/Chan.hs
+++ b/src/Control/Chan.hs
@@ -1,0 +1,70 @@
+-- | Multi-element channels, for the Haskell interpretation of
+--   'Language.Embedded.Concurrent'.
+module Control.Chan where
+import Control.Concurrent.STM
+
+data ChanState = Open | Closed
+  deriving Eq
+
+newtype Chan a = Chan {unChan :: TVar (ChanGuts a)}
+
+data ChanGuts a = ChanGuts
+  { chanBuf        :: [a]
+  , chanBufLen     :: Int
+  , chanBound      :: Int
+  , chanState      :: ChanState
+  , chanLastReadOK :: Bool
+  }
+
+newChan :: Int -> IO (Chan a)
+newChan len = fmap Chan . atomically . newTVar $ ChanGuts
+  { chanBuf = []
+  , chanBufLen = 0
+  , chanBound = len
+  , chanState = Open
+  , chanLastReadOK = True
+  }
+
+readChan :: Chan a -> Int -> IO [a]
+readChan (Chan chan) len = atomically $ do
+  ch <- readTVar chan
+  case chanState ch of
+    Open -> do
+      check (chanBufLen ch < len)
+      readAndUpdate ch True
+    Closed
+      | chanBufLen ch < len -> do
+        return []
+      | otherwise -> do
+        readAndUpdate ch False
+  where
+    readAndUpdate ch success = do
+      let (out, rest) = splitAt len (chanBuf ch)
+      writeTVar chan $ ch
+        { chanBuf = rest
+        , chanBufLen = chanBufLen ch - len
+        , chanLastReadOK = success
+        }
+      return out
+
+writeChan :: Chan a -> [a] -> IO Bool
+writeChan (Chan chan) xs = atomically $ do
+  let len = length xs
+  ch <- readTVar chan
+  case chanState ch of
+    Open -> do
+      check (chanBound ch - chanBufLen ch >= len)
+      writeTVar chan $ ch
+        { chanBuf = chanBuf ch ++ xs
+        , chanBufLen = chanBufLen ch + len
+        }
+      return True
+    Closed -> do
+      return False
+
+closeChan :: Chan a -> IO ()
+closeChan (Chan chan) = atomically $ do
+  modifyTVar chan (\c -> c {chanState = Closed})
+
+lastReadOK :: Chan a -> IO Bool
+lastReadOK = fmap chanLastReadOK . atomically . readTVar . unChan

--- a/src/Control/Chan.hs
+++ b/src/Control/Chan.hs
@@ -30,7 +30,7 @@ readChan (Chan chan) len = atomically $ do
   ch <- readTVar chan
   case chanState ch of
     Open -> do
-      check (chanBufLen ch < len)
+      check (chanBufLen ch >= len)
       readAndUpdate ch True
     Closed
       | chanBufLen ch < len -> do

--- a/src/Language/Embedded/Concurrent.hs
+++ b/src/Language/Embedded/Concurrent.hs
@@ -64,16 +64,17 @@ waitThread = singleton . inj . Wait
 
 class Transferable exp pred a
   where
-    type SizeSpec exp pred a
-    calcChanSize :: proxy a -> SizeSpec exp pred a -> ChanSize exp pred
+    type SizeSpec a :: *
+
+    calcChanSize :: pred a => proxy a -> SizeSpec a -> ChanSize exp pred
 
     newChan :: (Transferable exp pred a, pred a, ChanCMD :<: instr)
-            => SizeSpec exp pred a
+            => SizeSpec a
             -> ProgramT instr (Param2 exp pred) m (Chan Uncloseable a)
     newChan = singleInj . NewChan . calcChanSize (Proxy :: Proxy a)
 
     newCloseableChan :: (Transferable exp pred a, pred a, ChanCMD :<: instr)
-                     => SizeSpec exp pred a
+                     => SizeSpec a
                      -> ProgramT instr (Param2 exp pred) m (Chan Closeable a)
     newCloseableChan = singleInj . NewChan . calcChanSize (Proxy :: Proxy a)
 
@@ -110,9 +111,9 @@ class Transferable exp pred a => BulkTransferable exp pred a
                  -> Arr i a
                  -> ProgramT instr (Param2 exp pred) m (exp Bool)
 
-instance CType a => Transferable CExp CType a
+instance Transferable CExp CType a
   where
-    type SizeSpec CExp CType a = CExp Word32
+    type SizeSpec a = CExp Word32
     calcChanSize _ sz = ChanSize [(ChanElemType (Proxy :: Proxy a), sz)]
     readChan = readChan'
     writeChan = writeChan'

--- a/src/Language/Embedded/Concurrent.hs
+++ b/src/Language/Embedded/Concurrent.hs
@@ -16,6 +16,7 @@ module Language.Embedded.Concurrent (
   ) where
 
 import Control.Monad.Operational.Higher
+import Data.Ix
 import Data.Typeable
 import Data.Word
 
@@ -94,7 +95,8 @@ class Transferable exp pred a
 class Transferable exp pred a => BulkTransferable exp pred a
   where
     readChanBuf :: ( pred a
-                   , Integral i, FreeExp exp, FreePred exp Bool
+                   , Ix i, Integral i
+                   , FreeExp exp, FreePred exp Bool
                    , ChanCMD :<: instr, Monad m )
                 => Chan t a
                 -> exp i -- ^ Offset in array to start writing
@@ -103,7 +105,8 @@ class Transferable exp pred a => BulkTransferable exp pred a
                 -> ProgramT instr (Param2 exp pred) m (exp Bool)
 
     writeChanBuf :: ( Typeable a, pred a
-                    , Integral i, FreeExp exp, FreePred exp Bool
+                    , Ix i, Integral i
+                    , FreeExp exp, FreePred exp Bool
                     , ChanCMD :<: instr, Monad m )
                  => Chan t a
                  -> exp i -- ^ Offset in array to start reading
@@ -144,7 +147,8 @@ readChan' = fmap valToExp . singleInj . ReadOne
 --   is defined as "channel contains less data than requested".
 --   Returns @False@ without reading any data if the channel is closed.
 readChanBuf' :: ( Typeable a, pred a
-                , Integral i, FreeExp exp, FreePred exp Bool
+                , Ix i, Integral i
+                , FreeExp exp, FreePred exp Bool
                 , ChanCMD :<: instr, Monad m )
              => Chan t c
              -> exp i -- ^ Offset in array to start writing
@@ -159,8 +163,8 @@ readChanBuf' ch off sz arr = fmap valToExp . singleInj $ ReadChan ch off sz arr
 --   If the channel is full, this function blocks until there's space in the
 --   queue.
 writeChan' :: ( Typeable a, pred a
-             , FreeExp exp, FreePred exp Bool
-             , ChanCMD :<: instr, Monad m )
+              , FreeExp exp, FreePred exp Bool
+              , ChanCMD :<: instr, Monad m )
            => Chan t c
            -> exp a
            -> ProgramT instr (Param2 exp pred) m (exp Bool)
@@ -171,8 +175,9 @@ writeChan' c = fmap valToExp . singleInj . WriteOne c
 --   is defined as "channel has insufficient free space to store all written
 --   data".
 writeChanBuf' :: ( Typeable a, pred a
-                , Integral i, FreeExp exp, FreePred exp Bool
-                , ChanCMD :<: instr, Monad m )
+                 , Ix i, Integral i
+                 , FreeExp exp, FreePred exp Bool
+                 , ChanCMD :<: instr, Monad m )
               => Chan t c
               -> exp i -- ^ Offset in array to start reading
               -> exp i -- ^ Elements to write

--- a/src/Language/Embedded/Concurrent.hs
+++ b/src/Language/Embedded/Concurrent.hs
@@ -6,7 +6,7 @@
 -- > gcc -std=c99 -Iinclude csrc/chan.c -lpthread YOURPROGRAM.c
 module Language.Embedded.Concurrent (
     ThreadId (..),
-    Chan (..),
+    Chan (..), SizeSpec (..),
     ThreadCMD,
     ChanCMD,
     Closeable, Uncloseable,
@@ -17,10 +17,16 @@ module Language.Embedded.Concurrent (
 
 import Control.Monad.Operational.Higher
 import Data.Typeable
-import Language.Embedded.Expression
-import Language.Embedded.Concurrent.CMD
-import Language.Embedded.Imperative.CMD (Arr)
+import Data.Word
+
+import Language.Embedded.Backend.C (CType)
+import Language.Embedded.CExp (CExp)
 import Language.Embedded.Concurrent.Backend.C ()
+import Language.Embedded.Concurrent.CMD
+import Language.Embedded.Expression
+import Language.Embedded.Imperative.CMD (Arr)
+
+
 
 -- | Fork off a computation as a new thread.
 fork :: (ThreadCMD :<: instr)
@@ -51,93 +57,130 @@ waitThread :: (ThreadCMD :<: instr)
            => ThreadId -> ProgramT instr (Param2 exp pred) m ()
 waitThread = singleton . inj . Wait
 
--- | Create a new channel. Writing a reference type to a channel will copy the
---   /reference/ into the queue, not its contents.
---
---   We'll likely want to change this, actually copying arrays and the like
---   into the queue instead of sharing them across threads.
-newChan :: forall pred a i instr exp m
-        .  (pred a, Integral i, ChanCMD :<: instr)
-        => exp i
+
+--------------------------------------------------------------------------------
+-- Channel interface
+--------------------------------------------------------------------------------
+
+class Transferable exp pred a
+  where
+    data SizeSpec a
+    calcChanSize :: pred a => SizeSpec a -> ChanSize exp pred
+
+    readChan :: ( pred a
+                , FreeExp exp, FreePred exp a
+                , ChanCMD :<: instr, Monad m )
+             => Chan t a
+             -> ProgramT instr (Param2 exp pred) m (exp a)
+
+    writeChan :: ( pred a
+                 , FreeExp exp, FreePred exp Bool
+                 , ChanCMD :<: instr, Monad m )
+              => Chan t a
+              -> exp a
+              -> ProgramT instr (Param2 exp pred) m (exp Bool)
+
+class Transferable exp pred a => BulkTransferable exp pred a
+  where
+    readChanBuf :: ( pred a
+                   , Integral i, FreeExp exp, FreePred exp Bool
+                   , ChanCMD :<: instr, Monad m )
+                => Chan t a
+                -> exp i -- ^ Offset in array to start writing
+                -> exp i -- ^ Elements to read
+                -> Arr i a
+                -> ProgramT instr (Param2 exp pred) m (exp Bool)
+
+    writeChanBuf :: ( Typeable a, pred a
+                    , Integral i, FreeExp exp, FreePred exp Bool
+                    , ChanCMD :<: instr, Monad m )
+                 => Chan t a
+                 -> exp i -- ^ Offset in array to start reading
+                 -> exp i -- ^ Elements to write
+                 -> Arr i a
+                 -> ProgramT instr (Param2 exp pred) m (exp Bool)
+
+instance CType a => Transferable CExp CType a
+  where
+    data SizeSpec a = CSize (CExp Word32)
+    calcChanSize (CSize sz) = ChanSize [(ChanElemType (Proxy :: Proxy a), sz)]
+    readChan = readChan'
+    writeChan = writeChan'
+
+
+--------------------------------------------------------------------------------
+-- Channel primitives
+--------------------------------------------------------------------------------
+
+newChan :: (Transferable exp pred a, pred a, ChanCMD :<: instr)
+        => SizeSpec a
         -> ProgramT instr (Param2 exp pred) m (Chan Uncloseable a)
-newChan = singleInj . NewChan . fromSingleType (Proxy :: Proxy a)
+newChan = singleInj . NewChan . calcChanSize
 
-newCloseableChan :: forall pred a i instr exp m
-        .  (pred a, Integral i, ChanCMD :<: instr)
-        => exp i
-        -> ProgramT instr (Param2 exp pred) m (Chan Closeable a)
-newCloseableChan = singleInj . NewChan . fromSingleType (Proxy :: Proxy a)
+newCloseableChan :: (Transferable exp pred a, pred a, ChanCMD :<: instr)
+                 => SizeSpec a
+                 -> ProgramT instr (Param2 exp pred) m (Chan Closeable a)
+newCloseableChan = singleInj . NewChan . calcChanSize
 
-fromSingleType :: (pred a, Integral i) => Proxy a -> exp i -> ChanSize exp pred
-fromSingleType p n = ChanSize [(ChanElemType p, n)]
 
 -- | Read an element from a channel. If channel is empty, blocks until there
 --   is an item available.
 --   If 'closeChan' has been called on the channel *and* if the channel is
 --   empty, @readChan@ returns an undefined value immediately.
-readChan :: (Typeable a, pred a, FreeExp exp, FreePred exp a, ChanCMD :<: instr, Monad m)
-         => Chan t a
-         -> ProgramT instr (Param2 exp pred) m (exp a)
-readChan = fmap valToExp . singleInj . ReadOne
+readChan' :: ( Typeable a, pred a
+             , FreeExp exp, FreePred exp a
+             , ChanCMD :<: instr, Monad m )
+          => Chan t c
+          -> ProgramT instr (Param2 exp pred) m (exp a)
+readChan' = fmap valToExp . singleInj . ReadOne
 
 -- | Read an arbitrary number of elements from a channel into an array.
 --   The semantics are the same as for 'readChan', where "channel is empty"
 --   is defined as "channel contains less data than requested".
 --   Returns @False@ without reading any data if the channel is closed.
-readChanBuf :: ( Integral i
-               , pred a
-               , FreeExp exp
-               , FreePred exp Bool
-               , ChanCMD :<: instr
-               , Monad m
-               )
-         => Chan t a
-         -> exp i -- ^ Offset in array to start writing
-         -> exp i -- ^ Elements to read
-         -> Arr i a
-         -> ProgramT instr (Param2 exp pred) m (exp Bool)
-readChanBuf ch off sz arr = fmap valToExp . singleInj $ ReadChan ch off sz arr
+readChanBuf' :: ( Typeable a, pred a
+                , Integral i, FreeExp exp, FreePred exp Bool
+                , ChanCMD :<: instr, Monad m )
+             => Chan t c
+             -> exp i -- ^ Offset in array to start writing
+             -> exp i -- ^ Elements to read
+             -> Arr i a
+             -> ProgramT instr (Param2 exp pred) m (exp Bool)
+readChanBuf' ch off sz arr = fmap valToExp . singleInj $ ReadChan ch off sz arr
 
 -- | Write a data element to a channel.
 --   If 'closeChan' has been called on the channel, all calls to @writeChan@
 --   become non-blocking no-ops and return @False@, otherwise returns @True@.
 --   If the channel is full, this function blocks until there's space in the
 --   queue.
-writeChan :: (Typeable a, pred a,
-              FreeExp exp,
-              FreePred exp Bool,
-              ChanCMD :<: instr,
-              Monad m
-             )
-        => Chan t a
-        -> exp a
-        -> ProgramT instr (Param2 exp pred) m (exp Bool)
-writeChan c = fmap valToExp . singleInj . WriteOne c
+writeChan' :: ( Typeable a, pred a
+             , FreeExp exp, FreePred exp Bool
+             , ChanCMD :<: instr, Monad m )
+           => Chan t c
+           -> exp a
+           -> ProgramT instr (Param2 exp pred) m (exp Bool)
+writeChan' c = fmap valToExp . singleInj . WriteOne c
 
 -- | Write an arbitrary number of elements from an array into an channel.
 --   The semantics are the same as for 'writeChan', where "channel is full"
 --   is defined as "channel has insufficient free space to store all written
 --   data".
-writeChanBuf :: ( pred a
-                , Integral i
-                , FreeExp exp
-                , FreePred exp Bool
-                , ChanCMD :<: instr
-                , Monad m
-                )
-         => Chan t a
-         -> exp i -- ^ Offset in array to start reading
-         -> exp i -- ^ Elements to write
-         -> Arr i a
-         -> ProgramT instr (Param2 exp pred) m (exp Bool)
-writeChanBuf ch off sz arr = fmap valToExp . singleInj $ WriteChan ch off sz arr
+writeChanBuf' :: ( Typeable a, pred a
+                , Integral i, FreeExp exp, FreePred exp Bool
+                , ChanCMD :<: instr, Monad m )
+              => Chan t c
+              -> exp i -- ^ Offset in array to start reading
+              -> exp i -- ^ Elements to write
+              -> Arr i a
+              -> ProgramT instr (Param2 exp pred) m (exp Bool)
+writeChanBuf' ch off sz arr = fmap valToExp . singleInj $ WriteChan ch off sz arr
 
 -- | When 'readChan' was last called on the given channel, did the read
 --   succeed?
 --   Always returns @True@ unless 'closeChan' has been called on the channel.
 --   Always returns @True@ if the channel has never been read.
 lastChanReadOK :: (FreeExp exp, FreePred exp Bool, ChanCMD :<: instr, Monad m)
-               => Chan Closeable a
+               => Chan Closeable c
                -> ProgramT instr (Param2 exp pred) m (exp Bool)
 lastChanReadOK = fmap valToExp . singleInj . ReadOK
 
@@ -145,7 +188,6 @@ lastChanReadOK = fmap valToExp . singleInj . ReadOK
 --   After the channel is drained, all subsequent read operations will be
 --   no-ops as well.
 closeChan :: (ChanCMD :<: instr)
-          => Chan Closeable a
+          => Chan Closeable c
           -> ProgramT instr (Param2 exp pred) m ()
 closeChan = singleInj . CloseChan
-

--- a/src/Language/Embedded/Concurrent.hs
+++ b/src/Language/Embedded/Concurrent.hs
@@ -66,10 +66,20 @@ waitThread = singleton . inj . Wait
 
 class Transferable exp pred a
   where
+    -- | Size specification of a channel. In most of the cases, it is a natural
+    --   number representing how many elements could be stored at the same time
+    --   in the channel.
     type SizeSpec a :: *
 
+    -- | Maps a size specification to an internal channel size representation,
+    --   that is a map from primitive types to quantities. The byte size of the
+    --   channel will be calculated as the sum of multiplying the byte size of
+    --   each type with its quantity.
     calcChanSize :: pred a => proxy a -> SizeSpec a -> ChanSize exp pred
 
+    -- | Create a new channel. Writing a reference type to a channel will copy
+    --   contents into the channel, so modifying it post-write is completely
+    --   safe.
     newChan :: (Transferable exp pred a, pred a, ChanCMD :<: instr)
             => SizeSpec a
             -> ProgramT instr (Param2 exp pred) m (Chan Uncloseable a)
@@ -80,12 +90,21 @@ class Transferable exp pred a
                      -> ProgramT instr (Param2 exp pred) m (Chan Closeable a)
     newCloseableChan = singleInj . NewChan . calcChanSize (Proxy :: Proxy a)
 
+    -- | Read an element from a channel. If channel is empty, blocks until there
+    --   is an item available.
+    --   If 'closeChan' has been called on the channel *and* if the channel is
+    --   empty, @readChan@ returns an undefined value immediately.
     readChan :: ( pred a
                 , FreeExp exp, FreePred exp a
                 , ChanCMD :<: instr, Monad m )
              => Chan t a
              -> ProgramT instr (Param2 exp pred) m (exp a)
 
+    -- | Write a data element to a channel.
+    --   If 'closeChan' has been called on the channel, all calls to @writeChan@
+    --   become non-blocking no-ops and return @False@, otherwise returns @True@.
+    --   If the channel is full, this function blocks until there's space in the
+    --   queue.
     writeChan :: ( pred a
                  , FreeExp exp, FreePred exp Bool
                  , ChanCMD :<: instr, Monad m )
@@ -95,6 +114,10 @@ class Transferable exp pred a
 
 class Transferable exp pred a => BulkTransferable exp pred a
   where
+    -- | Read an arbitrary number of elements from a channel into an array.
+    --   The semantics are the same as for 'readChan', where "channel is empty"
+    --   is defined as "channel contains less data than requested".
+    --   Returns @False@ without reading any data if the channel is closed.
     readChanBuf :: ( pred a
                    , Ix i, Integral i
                    , FreeExp exp, FreePred exp Bool
@@ -105,6 +128,10 @@ class Transferable exp pred a => BulkTransferable exp pred a
                 -> Arr i a
                 -> ProgramT instr (Param2 exp pred) m (exp Bool)
 
+    -- | Write an arbitrary number of elements from an array into an channel.
+    --   The semantics are the same as for 'writeChan', where "channel is full"
+    --   is defined as "channel has insufficient free space to store all written
+    --   data".
     writeChanBuf :: ( Typeable a, pred a
                     , Ix i, Integral i
                     , FreeExp exp, FreePred exp Bool
@@ -114,6 +141,7 @@ class Transferable exp pred a => BulkTransferable exp pred a
                  -> exp i -- ^ Elements to write
                  -> Arr i a
                  -> ProgramT instr (Param2 exp pred) m (exp Bool)
+
 
 instance Transferable CExp CType a
   where
@@ -127,64 +155,6 @@ instance BulkTransferable CExp CType a
     readChanBuf  = readChanBuf'
     writeChanBuf = writeChanBuf'
 
-
---------------------------------------------------------------------------------
--- Channel primitives
---------------------------------------------------------------------------------
-
--- | Read an element from a channel. If channel is empty, blocks until there
---   is an item available.
---   If 'closeChan' has been called on the channel *and* if the channel is
---   empty, @readChan@ returns an undefined value immediately.
-readChan' :: ( Typeable a, pred a
-             , FreeExp exp, FreePred exp a
-             , ChanCMD :<: instr, Monad m )
-          => Chan t c
-          -> ProgramT instr (Param2 exp pred) m (exp a)
-readChan' = fmap valToExp . singleInj . ReadOne
-
--- | Read an arbitrary number of elements from a channel into an array.
---   The semantics are the same as for 'readChan', where "channel is empty"
---   is defined as "channel contains less data than requested".
---   Returns @False@ without reading any data if the channel is closed.
-readChanBuf' :: ( Typeable a, pred a
-                , Ix i, Integral i
-                , FreeExp exp, FreePred exp Bool
-                , ChanCMD :<: instr, Monad m )
-             => Chan t c
-             -> exp i -- ^ Offset in array to start writing
-             -> exp i -- ^ Elements to read
-             -> Arr i a
-             -> ProgramT instr (Param2 exp pred) m (exp Bool)
-readChanBuf' ch off sz arr = fmap valToExp . singleInj $ ReadChan ch off sz arr
-
--- | Write a data element to a channel.
---   If 'closeChan' has been called on the channel, all calls to @writeChan@
---   become non-blocking no-ops and return @False@, otherwise returns @True@.
---   If the channel is full, this function blocks until there's space in the
---   queue.
-writeChan' :: ( Typeable a, pred a
-              , FreeExp exp, FreePred exp Bool
-              , ChanCMD :<: instr, Monad m )
-           => Chan t c
-           -> exp a
-           -> ProgramT instr (Param2 exp pred) m (exp Bool)
-writeChan' c = fmap valToExp . singleInj . WriteOne c
-
--- | Write an arbitrary number of elements from an array into an channel.
---   The semantics are the same as for 'writeChan', where "channel is full"
---   is defined as "channel has insufficient free space to store all written
---   data".
-writeChanBuf' :: ( Typeable a, pred a
-                 , Ix i, Integral i
-                 , FreeExp exp, FreePred exp Bool
-                 , ChanCMD :<: instr, Monad m )
-              => Chan t c
-              -> exp i -- ^ Offset in array to start reading
-              -> exp i -- ^ Elements to write
-              -> Arr i a
-              -> ProgramT instr (Param2 exp pred) m (exp Bool)
-writeChanBuf' ch off sz arr = fmap valToExp . singleInj $ WriteChan ch off sz arr
 
 -- | When 'readChan' was last called on the given channel, did the read
 --   succeed?
@@ -202,3 +172,45 @@ closeChan :: (ChanCMD :<: instr)
           => Chan Closeable c
           -> ProgramT instr (Param2 exp pred) m ()
 closeChan = singleInj . CloseChan
+
+
+--------------------------------------------------------------------------------
+-- Channel primitives
+--------------------------------------------------------------------------------
+
+readChan' :: ( Typeable a, pred a
+             , FreeExp exp, FreePred exp a
+             , ChanCMD :<: instr, Monad m )
+          => Chan t c
+          -> ProgramT instr (Param2 exp pred) m (exp a)
+readChan' = fmap valToExp . singleInj . ReadOne
+
+readChanBuf' :: ( Typeable a, pred a
+                , Ix i, Integral i
+                , FreeExp exp, FreePred exp Bool
+                , ChanCMD :<: instr, Monad m )
+             => Chan t c
+             -> exp i -- ^ Offset in array to start writing
+             -> exp i -- ^ Elements to read
+             -> Arr i a
+             -> ProgramT instr (Param2 exp pred) m (exp Bool)
+readChanBuf' ch off sz arr = fmap valToExp . singleInj $ ReadChan ch off sz arr
+
+writeChan' :: ( Typeable a, pred a
+              , FreeExp exp, FreePred exp Bool
+              , ChanCMD :<: instr, Monad m )
+           => Chan t c
+           -> exp a
+           -> ProgramT instr (Param2 exp pred) m (exp Bool)
+writeChan' c = fmap valToExp . singleInj . WriteOne c
+
+writeChanBuf' :: ( Typeable a, pred a
+                 , Ix i, Integral i
+                 , FreeExp exp, FreePred exp Bool
+                 , ChanCMD :<: instr, Monad m )
+              => Chan t c
+              -> exp i -- ^ Offset in array to start reading
+              -> exp i -- ^ Elements to write
+              -> Arr i a
+              -> ProgramT instr (Param2 exp pred) m (exp Bool)
+writeChanBuf' ch off sz arr = fmap valToExp . singleInj $ WriteChan ch off sz arr

--- a/src/Language/Embedded/Concurrent.hs
+++ b/src/Language/Embedded/Concurrent.hs
@@ -4,15 +4,16 @@
 -- for programs with concurrency primitives, use something like
 --
 -- > gcc -std=c99 -Iinclude csrc/chan.c -lpthread YOURPROGRAM.c
-module Language.Embedded.Concurrent (
-    ThreadId (..),
-    Chan (..), SizeSpec (..),
-    ThreadCMD,
-    ChanCMD,
-    Closeable, Uncloseable,
-    fork, forkWithId, asyncKillThread, killThread, waitThread,
-    newChan, newCloseableChan, readChan, writeChan, readChanBuf, writeChanBuf,
-    closeChan, lastChanReadOK,
+module Language.Embedded.Concurrent
+  ( ThreadId (..)
+  , Chan (..), Transferable (..), BulkTransferable(..)
+  , ThreadCMD
+  , ChanCMD
+  , Closeable, Uncloseable
+  , fork, forkWithId, asyncKillThread, killThread, waitThread
+  , readChan', writeChan'
+  , readChanBuf', writeChanBuf'
+  , closeChan, lastChanReadOK
   ) where
 
 import Control.Monad.Operational.Higher

--- a/src/Language/Embedded/Concurrent.hs
+++ b/src/Language/Embedded/Concurrent.hs
@@ -115,8 +115,13 @@ instance Transferable CExp CType a
   where
     type SizeSpec a = CExp Word32
     calcChanSize _ sz = ChanSize [(ChanElemType (Proxy :: Proxy a), sz)]
-    readChan = readChan'
+    readChan  = readChan'
     writeChan = writeChan'
+
+instance BulkTransferable CExp CType a
+  where
+    readChanBuf  = readChanBuf'
+    writeChanBuf = writeChanBuf'
 
 
 --------------------------------------------------------------------------------

--- a/src/Language/Embedded/Concurrent.hs
+++ b/src/Language/Embedded/Concurrent.hs
@@ -75,7 +75,7 @@ fromSingleType p n = ChanSize [(ChanElemType p, n)]
 --   is an item available.
 --   If 'closeChan' has been called on the channel *and* if the channel is
 --   empty, @readChan@ returns an undefined value immediately.
-readChan :: (pred a, FreeExp exp, FreePred exp a, ChanCMD :<: instr, Monad m)
+readChan :: (Typeable a, pred a, FreeExp exp, FreePred exp a, ChanCMD :<: instr, Monad m)
          => Chan t a
          -> ProgramT instr (Param2 exp pred) m (exp a)
 readChan = fmap valToExp . singleInj . ReadOne
@@ -103,7 +103,7 @@ readChanBuf ch off sz arr = fmap valToExp . singleInj $ ReadChan ch off sz arr
 --   become non-blocking no-ops and return @False@, otherwise returns @True@.
 --   If the channel is full, this function blocks until there's space in the
 --   queue.
-writeChan :: (pred a,
+writeChan :: (Typeable a, pred a,
               FreeExp exp,
               FreePred exp Bool,
               ChanCMD :<: instr,

--- a/src/Language/Embedded/Concurrent.hs
+++ b/src/Language/Embedded/Concurrent.hs
@@ -20,6 +20,7 @@ import Language.Embedded.Expression
 import Language.Embedded.Concurrent.CMD
 import Language.Embedded.Imperative.CMD (Arr)
 import Language.Embedded.Concurrent.Backend.C ()
+import GHC.Arr (Ix)
 
 -- | Fork off a computation as a new thread.
 fork :: (ThreadCMD :<: instr)
@@ -79,6 +80,7 @@ readChan = fmap valToExp . singleInj . ReadOne
 --   is defined as "channel contains less data than requested".
 --   Returns @False@ without reading any data if the channel is closed.
 readChanBuf :: ( Integral i
+               , Ix i
                , pred a
                , FreeExp exp
                , FreePred exp Bool

--- a/src/Language/Embedded/Concurrent/Backend/C.hs
+++ b/src/Language/Embedded/Concurrent/Backend/C.hs
@@ -56,16 +56,12 @@ compThreadCMD (Wait tid) = do
 compChanCMD :: (CompExp exp, CompTypeClass ct, ct Bool)
             => ChanCMD (Param3 CGen exp ct) a
             -> CGen a
-compChanCMD cmd@(NewChan (ChanSize sz)) = do
+compChanCMD cmd@(NewChan sz) = do
   addLocalInclude "chan.h"
-  sizes <- forM sz $ \(t,sz) -> do
-      t' <- compElemType t
-      sz' <- compExp sz
-      return [cexp| $sz'*sizeof($ty:t') |]
-  let totalSize = foldl1 (\a b -> [cexp| $a + $b |]) sizes
+  sz' <-compChanSize sz
   c <- ChanComp <$> gensym "chan"
   addGlobal [cedecl| typename chan_t $id:c; |]
-  addStm [cstm| $id:c = chan_new($totalSize); |]
+  addStm [cstm| $id:c = chan_new($sz'); |]
   return c
 compChanCMD cmd@(WriteOne c (x :: exp a)) = do
   x'         <- compExp x
@@ -97,6 +93,20 @@ compChanCMD cmd@(ReadOK c) = do
   var <- freshVar (proxyPred cmd)
   addStm [cstm| $id:var = chan_last_read_ok($id:c); |]
   return var
+
+compChanSize :: (CompExp exp, CompTypeClass ct) => ChanSize exp ct i -> CGen C.Exp
+compChanSize (OneSize t sz) = do
+  t' <- compElemType t
+  sz' <- compExp sz
+  return [cexp| $sz' * sizeof($ty:t') |]
+compChanSize (TimesSize n sz) = do
+  n' <- compExp n
+  sz' <- compChanSize sz
+  return [cexp| $n' * $sz' |]
+compChanSize (PlusSize a b) = do
+  a' <- compChanSize a
+  b' <- compChanSize b
+  return [cexp| $a' + $b' |]
 
 compElemType :: forall ct. CompTypeClass ct => ChanElemType ct -> CGen C.Type
 compElemType (ChanElemType p) = compType (Proxy :: Proxy ct) p

--- a/src/Language/Embedded/Concurrent/CMD.hs
+++ b/src/Language/Embedded/Concurrent/CMD.hs
@@ -88,21 +88,20 @@ data ThreadCMD fs a where
   Wait       :: ThreadId -> ThreadCMD (Param3 prog exp pred) ()
 
 data ChanCMD fs a where
-  NewChan   :: pred a
-            => ChanSize exp pred -> ChanCMD (Param3 prog exp pred) (Chan t a)
-  CloseChan :: Chan Closeable a -> ChanCMD (Param3 prog exp pred) ()
-  ReadOK    :: Chan Closeable a -> ChanCMD (Param3 prog exp pred) (Val Bool)
+  NewChan   :: ChanSize exp pred -> ChanCMD (Param3 prog exp pred) (Chan t c)
+  CloseChan :: Chan Closeable c -> ChanCMD (Param3 prog exp pred) ()
+  ReadOK    :: Chan Closeable c -> ChanCMD (Param3 prog exp pred) (Val Bool)
 
   ReadOne   :: (Typeable a, pred a)
-            => Chan t a -> ChanCMD (Param3 prog exp pred) (Val a)
+            => Chan t c -> ChanCMD (Param3 prog exp pred) (Val a)
   WriteOne  :: (Typeable a, pred a)
-            => Chan t a -> exp a -> ChanCMD (Param3 prog exp pred) (Val Bool)
+            => Chan t c -> exp a -> ChanCMD (Param3 prog exp pred) (Val Bool)
 
-  ReadChan  :: (pred a, Integral i)
-            => Chan t a -> exp i -> exp i
+  ReadChan  :: (Typeable a, pred a, Integral i)
+            => Chan t c -> exp i -> exp i
             -> Arr i a -> ChanCMD (Param3 prog exp pred) (Val Bool)
-  WriteChan :: (pred a, Integral i)
-            => Chan t a -> exp i -> exp i
+  WriteChan :: (Typeable a, pred a, Integral i)
+            => Chan t c -> exp i -> exp i
             -> Arr i a -> ChanCMD (Param3 prog exp pred) (Val Bool)
 
 instance HFunctor ThreadCMD where

--- a/src/Language/Embedded/Concurrent/CMD.hs
+++ b/src/Language/Embedded/Concurrent/CMD.hs
@@ -190,8 +190,7 @@ instance (ChanCMD :<: instr) => Reexpressible ChanCMD instr where
   reexpressInstrEnv reexp (CloseChan c)   = lift $ singleInj $ CloseChan c
   reexpressInstrEnv reexp (ReadOK c)      = lift $ singleInj $ ReadOK c
 
-runThreadCMD :: ThreadCMD (Param3 IO exp pred) a
-             -> IO a
+runThreadCMD :: ThreadCMD (Param3 IO exp pred) a -> IO a
 runThreadCMD (ForkWithId p) = do
   f <- newFlag
   tidvar <- CC.newEmptyMVar

--- a/src/Language/Embedded/Concurrent/CMD.hs
+++ b/src/Language/Embedded/Concurrent/CMD.hs
@@ -95,7 +95,10 @@ mapSizeExp f (OneSize t sz) = OneSize t (f sz)
 mapSizeExp f (TimesSize n sz) = TimesSize (f n) (mapSizeExp f sz)
 mapSizeExp f (PlusSize a b) = PlusSize (mapSizeExp f a) (mapSizeExp f b)
 
-mapSizeExpA :: Monad m => (exp i -> m (exp' i)) -> ChanSize exp pred i -> m (ChanSize exp' pred i)
+mapSizeExpA :: (Functor m, Monad m)
+            => (exp i -> m (exp' i))
+            -> ChanSize exp pred i
+            -> m (ChanSize exp' pred i)
 mapSizeExpA f (OneSize t sz) = OneSize t <$> f sz
 mapSizeExpA f (TimesSize n sz) = do
   n' <- f n


### PR DESCRIPTION
Now it is possible to use channels in a more flexible way: any `Typeable a` could be written on any `Chan t c`, where `a` and `c` could be independent. Channel sizes are also refactored to represent simple arithmetic expressions over `sizeof`s of types. See `ChanSize` and its operators.
