### PR TITLE
Support for aligned arrays

### DIFF
--- a/src/Language/Embedded/Imperative/Frontend.hs
+++ b/src/Language/Embedded/Imperative/Frontend.hs
@@ -105,6 +105,13 @@ newArr :: (pred a, Integral i, Ix i, ArrCMD :<: instr)
     -> ProgramT instr (Param2 exp pred) m (Arr i a)
 newArr = newNamedArr "a"
 
+-- | Create an uninitialized array with the specified optional alignment
+newAlignedArr :: (pred a, Integral i, Ix i, ArrCMD :<: instr)
+    => Maybe i  -- ^ Optional alignment
+    -> exp i    -- ^ Length
+    -> ProgramT instr (Param2 exp pred) m (Arr i a)
+newAlignedArr = newNamedAlignedArr "a"
+
 -- | Create an uninitialized named array
 --
 -- The provided base name may be appended with a unique identifier to avoid name
@@ -113,13 +120,31 @@ newNamedArr :: (pred a, Integral i, Ix i, ArrCMD :<: instr)
     => String -- ^ Base name
     -> exp i  -- ^ Length
     -> ProgramT instr (Param2 exp pred) m (Arr i a)
-newNamedArr base len = singleInj (NewArr base len)
+newNamedArr base len = newNamedAlignedArr base Nothing len
+
+-- | Create an uninitialized named array with the specified optional alignment
+--
+-- The provided base name may be appended with a unique identifier to avoid name
+-- collisions.
+newNamedAlignedArr :: (pred a, Integral i, Ix i, ArrCMD :<: instr)
+    => String   -- ^ Base name
+    -> Maybe i  -- ^ Optional alignment
+    -> exp i    -- ^ Length
+    -> ProgramT instr (Param2 exp pred) m (Arr i a)
+newNamedAlignedArr base al len = singleInj (NewArr base al len)
 
 -- | Create and initialize an array
 initArr :: (pred a, Integral i, Ix i, ArrCMD :<: instr)
     => [a]  -- ^ Initial contents
     -> ProgramT instr (Param2 exp pred) m (Arr i a)
 initArr = initNamedArr "a"
+
+-- | Create and initialize an array with the specified optional alignment
+initAlignedArr :: (pred a, Integral i, Ix i, ArrCMD :<: instr)
+    => Maybe i  -- ^ Optional alignment
+    -> [a]      -- ^ Initial contents
+    -> ProgramT instr (Param2 exp pred) m (Arr i a)
+initAlignedArr = initNamedAlignedArr "a"
 
 -- | Create and initialize a named array
 --
@@ -129,7 +154,18 @@ initNamedArr :: (pred a, Integral i, Ix i, ArrCMD :<: instr)
     => String  -- ^ Base name
     -> [a]     -- ^ Initial contents
     -> ProgramT instr (Param2 exp pred) m (Arr i a)
-initNamedArr base init = singleInj (InitArr base init)
+initNamedArr base init = initNamedAlignedArr base Nothing init
+
+-- | Create and initialize a named array with the specified optional alignment
+--
+-- The provided base name may be appended with a unique identifier to avoid name
+-- collisions.
+initNamedAlignedArr :: (pred a, Integral i, Ix i, ArrCMD :<: instr)
+    => String   -- ^ Base name
+    -> Maybe i  -- ^ Optional alignment
+    -> [a]      -- ^ Initial contents
+    -> ProgramT instr (Param2 exp pred) m (Arr i a)
+initNamedAlignedArr base al init = singleInj (InitArr base al init)
 
 -- | Get an element of an array
 getArr

--- a/src/Language/Embedded/Imperative/Frontend/General.hs
+++ b/src/Language/Embedded/Imperative/Frontend/General.hs
@@ -32,5 +32,5 @@ import qualified System.IO as IO
 import Language.Embedded.Imperative.CMD
 
 import Language.C.Syntax
-import Language.C.Quote.C
+import Language.C.Quote.GCC
 


### PR DESCRIPTION
As it turned out the alignment attribute is not standardized in C99, it is available as a GNU extension. So I needed to change the quoter import. The compilation is a bit repetitive, but unfortunately there is no quasiquoter for attributes, so I was unable to assemble the attribute before application. And in each case, we use a slightly different type of C expression...

However, this change must not be reflected now in RAW-Feldspar, as I found another way to apply alignments. In my parallella compiler, I can traverse the program through its view and rewrite each array creation command to insert my fixed alignment. So I only use the extended representation and its compilation, but not its frontend.
