### PR TITLE
Support for aligned arrays with new C commands

### DIFF
--- a/src/Language/Embedded/Imperative/Frontend/General.hs
+++ b/src/Language/Embedded/Imperative/Frontend/General.hs
@@ -32,5 +32,5 @@ import qualified System.IO as IO
 import Language.Embedded.Imperative.CMD
 
 import Language.C.Syntax
-import Language.C.Quote.C
+import Language.C.Quote.GCC
 


### PR DESCRIPTION
Well, I am not sure that this version is much better than the previous one. I just added the two new commands and forwarded the run instances of C_CMD to ArrCMD, and the compilation instances from ArrCMD to C_CMD. As I am rewriting alignments on the program view in my feldspar extension, I don't need any frontend functions, so I omitted them.
